### PR TITLE
Change RetentionPolicy on @Nullable from CLASS to RUNTIME

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-projectVersion=16.0.1
+projectVersion=16.0.2

--- a/java8/src/main/java/org/jetbrains/annotations/Nullable.java
+++ b/java8/src/main/java/org/jetbrains/annotations/Nullable.java
@@ -37,7 +37,7 @@ import java.lang.annotation.*;
  * @author max
  */
 @Documented
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
 public @interface Nullable {
   String value() default "";


### PR DESCRIPTION
Change RetentionPolicy on @Nullable from CLASS to RUNTIME. A use case for this change is to be able to write unit tests for verify and/or enforce use of such annotations.
* Bump version number patch level per contributors guidelines.