### PR TITLE
Fix apache license url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ configure([project(':java5'), project(':java8')]) {
                         licenses {
                             license {
                                 name 'The Apache Software License, Version 2.0'
-                                url 'http://www.apache.org/license/LICENSE-2.0.txt'
+                                url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                                 distribution 'repo'
                             }
                         }


### PR DESCRIPTION
I noticed the wrong url because I use a gradle plugin to generate a third party licenses report it was not able to group your dependency with other apache 2.0 dependencies. :)