### PR TITLE
Add @Range annotation to set a boundary for number parameters or array parameters

### DIFF
--- a/java8/src/main/java/org/jetbrains/annotations/Range.java
+++ b/java8/src/main/java/org/jetbrains/annotations/Range.java
@@ -1,0 +1,29 @@
+package org.jetbrains.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation defines the allowed range of a number parameter.
+ * The method may throw an {@link IllegalArgumentException} if the parameter is not within its bounds.
+ * If the annotation is used on a {@code VarArgs} parameter, it describes the minimum and maximum amount of arguments.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.PARAMETER)
+public @interface Range {
+    /**
+     * Defines the minimum value of the number. Default is {@code 0}.
+     *
+     * @return The minimum value of the number.
+     */
+    long min() default 0;
+
+    /**
+     * Defines the maximum value of the number.
+     *
+     * @return The maximum value oif the number.
+     */
+    long max();
+}


### PR DESCRIPTION
The Annotation is documented as intended.

```
This annotation defines the allowed range of a number parameter.
The method may throw an {@link IllegalArgumentException} if the parameter is not within its bounds.
If the annotation is used on a {@code VarArgs} parameter, it describes the minimum and maximum amount of arguments.
```

Of course, this PR is missing all logic towards this annotation, this PR mostly serves as an idea that I want to share to the JetBrains team.

In example, IntelliJ could, if wanted by the user, add range-checking snippets before compiling; the same goes for things like the `@Nullable` annotation.