### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The annotations are published on [Maven Central](http://repo1.maven.org/maven2/o
 using gradle write the following in `build.gradle` file:
 ```
 dependencies {
-    compile 'org.jetbrains:annotations:17.0.0'
+    compileOnly 'org.jetbrains:annotations:17.0.0'
 }
 
 ```


### PR DESCRIPTION
The package can be included as `compileOnly` dependency.

If my understanding is correct, retention policy `CLASS` means that while the annotations will be present in the byte code  -- e.g. for IDEA to pick up and use in data flow analyses -- we will not expect to see them at runtime. Therefore

Not 100% sure what happens if a library using the annotations from this package (via `compileOnly`) is in turn included as dependency in some application; would `org.jetbrains:annotations` then be necessary, and is it picked up for the `compile` configuration of the application?