### PR TITLE
Prohibit instantiation of namespace-like classes

### DIFF
--- a/common/src/main/java/org/intellij/lang/annotations/JdkConstants.java
+++ b/common/src/main/java/org/intellij/lang/annotations/JdkConstants.java
@@ -23,8 +23,7 @@ import java.awt.event.InputEvent;
 import java.util.Calendar;
 import java.util.regex.Pattern;
 
-@SuppressWarnings("EmptyClass")
-public class JdkConstants {
+public final class JdkConstants {
 
   /**
    * Prohibited default constructor.

--- a/common/src/main/java/org/intellij/lang/annotations/JdkConstants.java
+++ b/common/src/main/java/org/intellij/lang/annotations/JdkConstants.java
@@ -25,6 +25,14 @@ import java.util.regex.Pattern;
 
 @SuppressWarnings("EmptyClass")
 public class JdkConstants {
+
+  /**
+   * Prohibited default constructor.
+   */
+  private JdkConstants() {
+    throw new AssertionError("JdkConstants should not be instantiated");
+  }
+
   @MagicConstant(intValues = {SwingConstants.LEFT, SwingConstants.CENTER, SwingConstants.RIGHT, SwingConstants.LEADING, SwingConstants.TRAILING})
   public @interface HorizontalAlignment {}
 

--- a/common/src/main/java/org/jetbrains/annotations/ApiStatus.java
+++ b/common/src/main/java/org/jetbrains/annotations/ApiStatus.java
@@ -23,6 +23,14 @@ import java.lang.annotation.*;
  * @since 18.0.0
  */
 public final class ApiStatus {
+
+  /**
+   * Prohibited default constructor.
+   */
+  private ApiStatus() {
+    throw new AssertionError("ApiStatus should not be instantiated");
+  }
+
   /**
    * <p>Indicates that a public API of the annotated element (class, method or field) is not in stable state yet. It may be renamed, changed or
    * even removed in a future version. This annotation refers to API status only, it doesn't mean that the implementation has

--- a/common/src/main/java/org/jetbrains/annotations/Async.java
+++ b/common/src/main/java/org/jetbrains/annotations/Async.java
@@ -29,6 +29,13 @@ import java.lang.annotation.Target;
 public final class Async {
 
   /**
+   * Prohibited default constructor.
+   */
+  private Async() {
+    throw new AssertionError("Async should not be instantiated");
+  }
+
+  /**
    * Indicates that the marked method schedules async computation.
    * Scheduled object is either {@code this}, or the annotated parameter value.
    */

--- a/common/src/main/java/org/jetbrains/annotations/Debug.java
+++ b/common/src/main/java/org/jetbrains/annotations/Debug.java
@@ -26,6 +26,14 @@ import java.lang.annotation.Target;
  * @since 18.0.0
  */
 public final class Debug {
+
+  /**
+   * Prohibited default constructor.
+   */
+  private Debug() {
+    throw new AssertionError("Debug should not be instantiated");
+  }
+
   /**
    * Allows to change the presentation of an object in debuggers
    */


### PR DESCRIPTION
This PR adds private throwing constructors to the classes which server the purpose of namespaces for annotations.