### PR TITLE
Change scope of artifact to "provided"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To add a dependency using Maven, write the following in `pom.xml`:
   <groupId>org.jetbrains</groupId>
   <artifactId>annotations</artifactId>
   <version>20.1.0</version>
+  <scope>provided</scope>
 </dependency>
 ```
 


### PR DESCRIPTION
The annotations are not needed at runtime. They only provide hints to the IDE about how the code works. The Gradle example uses `compileOnly`, using Maven's `provided` scope will perform the same thing. It causes the dependency to be made available during compilation but not at runtime. (The fact that it assumes it will be "provided" at runtime is irrelevant, it simply doesn't need to be provided.)

Note that using the provided scope is more correct than using `<optional>true</optional>` since making something optional only affects downstream projects that depend on your own. It will still be made available at runtime.