### PR TITLE
fix(build): add Multi-Release attribute to manifest of jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ configure([project(':java5'), project(':java8')]) {
                 include("module-info.class")
             })
         })
+        manifest.attributes("Multi-Release": true)
         duplicatesStrategy = DuplicatesStrategy.FAIL
     }
 


### PR DESCRIPTION
https://docs.oracle.com/javase/10/docs/specs/jar/jar.html#multi-release-jar-files

The `Multi-Release` attribute was not included in JARs, rendering the multi-release code (module-info) useless.