### PR TITLE
Include TYPE_PARAMETER target in NotNull and Nullable annotations

### DIFF
--- a/common/src/main/java/org/jetbrains/annotations/NotNull.java
+++ b/common/src/main/java/org/jetbrains/annotations/NotNull.java
@@ -26,7 +26,7 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface NotNull {
   /**
    * @return Custom exception message

--- a/common/src/main/java/org/jetbrains/annotations/Nullable.java
+++ b/common/src/main/java/org/jetbrains/annotations/Nullable.java
@@ -36,7 +36,7 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface Nullable {
   /**
    * @return textual reason when the annotated value could be null, for documentation purposes.


### PR DESCRIPTION
I'm in the process of moving my code to use `org.jetbrains:annotations` instead of `org.checkerframework:checker-qual`, and noticed this difference in the annotations while moving over.

Similar to the annotations included with checker-qual  ([`NonNull`](https://github.com/typetools/checker-framework/blob/master/checker-qual/src/main/java/org/checkerframework/checker/nullness/qual/NonNull.java), [`Nullable`](https://github.com/typetools/checker-framework/blob/master/checker-qual/src/main/java/org/checkerframework/checker/nullness/qual/Nullable.java)), include the `TYPE_PARAMETER` target in the `NotNull` and `Nullable` annotations.



