### PR TITLE
Reactive blocking context aware annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ===
 
+Version 22.0.0
+---
+* Added new annotations: `@Blocking` and `@NonBlocking`.
+
 Version 21.0.1
 ---
 * Multi-Release Jar: Manifest fixed 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ import jetbrains.sign.GpgSignSignatoryProvider
 
 buildscript {
     repositories {
-        jcenter()
         maven { url "https://packages.jetbrains.team/maven/p/jcs/maven" }
     }
     dependencies {

--- a/common/src/main/java/org/jetbrains/annotations/Blocking.java
+++ b/common/src/main/java/org/jetbrains/annotations/Blocking.java
@@ -1,0 +1,20 @@
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Indicates that the annotated method is inherently blocking and should not be executed in a non-blocking context.
+ * <p>
+ * When this annotation is used on a {@code class}, all the methods declared by the annotated class are considered
+ * <em>blocking</em>.
+ * <p>
+ * Apart from documentation purposes this annotation is intended to be used by static analysis tools to validate against
+ * probable runtime errors and element contract violations.
+ *
+ * @since 22.0.0
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE})
+public @interface Blocking {
+}

--- a/common/src/main/java/org/jetbrains/annotations/NonBlocking.java
+++ b/common/src/main/java/org/jetbrains/annotations/NonBlocking.java
@@ -1,0 +1,20 @@
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Indicates that the annotated method is inherently non-blocking and can be executed in a non-blocking context.
+ * <p>
+ * When this annotation is used on a {@code class}, all the methods declared by the annotated class are considered
+ * <em>non-blocking</em>.
+ * <p>
+ * Apart from documentation purposes this annotation is intended to be used by static analysis tools to validate against
+ * probable runtime errors and contract violations.
+ *
+ * @since 22.0.0
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE})
+public @interface NonBlocking {
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-projectVersion=21.0.1
+projectVersion=22.0.0
 #JDK_5=<path-to-older-java-version>


### PR DESCRIPTION
Here we introduce `@Blocking` and `@NonBlocking` annotations that are used by IntelliJ IDEA to detect inappropriate blocking calls in non-blocking contexts. Some reactive frameworks, have similar annotations, e.g. SmallRye Mutiny: https://smallrye.io/docs/smallrye-fault-tolerance/5.2.1/usage/extra.html#blocking-nonblocking