### PR TITLE
Add `@ApiStatus.Experimental` to mutates method

### DIFF
--- a/common/src/main/java/org/jetbrains/annotations/Contract.java
+++ b/common/src/main/java/org/jetbrains/annotations/Contract.java
@@ -101,5 +101,7 @@ public @interface Contract {
    * <strong>Warning: This annotation parameter is experimental and may be changed or removed without further notice!</strong>
    * @return a mutation specifier string
    */
-  @NonNls String mutates() default "";
+  @ApiStatus.Experimental
+  @NonNls
+  String mutates() default "";
 }


### PR DESCRIPTION
The mutates method has a warning in the Javadoc saying that it is experimental but it's not annotated with `@ApiStatus.Experimental`