### PR TITLE
Fix typo in Subst.java

### DIFF
--- a/common/src/main/java/org/intellij/lang/annotations/Subst.java
+++ b/common/src/main/java/org/intellij/lang/annotations/Subst.java
@@ -33,7 +33,7 @@ import java.lang.annotation.*;
  *   + ... + "&lt;/span&gt;&lt;/html&gt;";
  * </pre>
  * <p>
- * Here the parser assumes that when {@code font} appears in the concatenation it's value is {@code "Tahoma"},
+ * Here the parser assumes that when {@code font} appears in the concatenation its value is {@code "Tahoma"},
  * so it can continue parsing the concatenation.
  * </p>
  *

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-projectVersion=23.0.0
+projectVersion=23.0.1
 #JDK_5=<path-to-older-java-version>


### PR DESCRIPTION
Fixes a minor typo in part of the Javadoc. 