### PR TITLE
Add @Documented where it's currently missing

### DIFF
--- a/common/src/main/java/org/intellij/lang/annotations/Language.java
+++ b/common/src/main/java/org/intellij/lang/annotations/Language.java
@@ -18,6 +18,7 @@ package org.intellij.lang.annotations;
 
 import org.jetbrains.annotations.NonNls;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -41,6 +42,7 @@ import static java.lang.annotation.ElementType.*;
  * Note that using the derived annotation as meta-annotation is not supported.
  * Meta-annotation works only one level deep.
  */
+@Documented
 @Retention(RetentionPolicy.CLASS)
 @Target({ METHOD, FIELD, PARAMETER, LOCAL_VARIABLE, ANNOTATION_TYPE })
 public @interface Language {

--- a/common/src/main/java/org/intellij/lang/annotations/MagicConstant.java
+++ b/common/src/main/java/org/intellij/lang/annotations/MagicConstant.java
@@ -75,6 +75,7 @@ import java.lang.annotation.*;
  *
  * The <code>@MagicConstant</code> annotation has SOURCE retention, i.e. it is removed upon compilation and does not create any runtime overhead.
  */
+@Documented
 @Retention(RetentionPolicy.SOURCE)
 @Target({
           ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE,

--- a/common/src/main/java/org/intellij/lang/annotations/Pattern.java
+++ b/common/src/main/java/org/intellij/lang/annotations/Pattern.java
@@ -19,6 +19,7 @@ package org.intellij.lang.annotations;
 import org.jetbrains.annotations.NonNls;
 
 import static java.lang.annotation.ElementType.*;
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -42,6 +43,7 @@ import java.lang.annotation.Target;
  *
  * @see RegExp
  */
+@Documented
 @Retention(RetentionPolicy.CLASS)
 @Target({ METHOD, FIELD, PARAMETER, LOCAL_VARIABLE, ANNOTATION_TYPE })
 public @interface Pattern {

--- a/common/src/main/java/org/intellij/lang/annotations/PrintFormat.java
+++ b/common/src/main/java/org/intellij/lang/annotations/PrintFormat.java
@@ -15,6 +15,8 @@
  */
 package org.intellij.lang.annotations;
 
+import java.lang.annotation.Documented;
+
 /**
  * Specifies that the method parameter is a printf-style print format pattern,
  * as described in {@link java.util.Formatter}.
@@ -35,6 +37,7 @@ package org.intellij.lang.annotations;
  *
  * @see Pattern
  */
+@Documented
 @Pattern(PrintFormatPattern.PRINT_FORMAT)
 public @interface PrintFormat {
 }

--- a/common/src/main/java/org/intellij/lang/annotations/RegExp.java
+++ b/common/src/main/java/org/intellij/lang/annotations/RegExp.java
@@ -18,6 +18,7 @@ package org.intellij.lang.annotations;
 import org.jetbrains.annotations.NonNls;
 
 import static java.lang.annotation.ElementType.*;
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -31,6 +32,7 @@ import java.lang.annotation.Target;
  *
  * @see Language
  */
+@Documented
 @Retention(RetentionPolicy.CLASS)
 @Target({METHOD, FIELD, PARAMETER, LOCAL_VARIABLE, ANNOTATION_TYPE})
 @Language("RegExp")

--- a/common/src/main/java/org/jetbrains/annotations/CheckReturnValue.java
+++ b/common/src/main/java/org/jetbrains/annotations/CheckReturnValue.java
@@ -1,5 +1,6 @@
 package org.jetbrains.annotations;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
@@ -27,6 +28,7 @@ import java.lang.annotation.Target;
  *
  * @see Contract#pure()
  */
+@Documented
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.PACKAGE})
 @ApiStatus.Experimental
 public @interface CheckReturnValue {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-projectVersion=24.0.0
+projectVersion=24.0.1
 #JDK_5=<path-to-older-java-version>


### PR DESCRIPTION
While writing a library, I found that `@Language` annotations and the resulting code highlighting in IntelliJ did not show up in projects implementing the library. I reckoned that adding `@Documented` where it was currently missing would improve the overall usability of the annotations in this project.
I chose to only increase the patch version and not the minor version as this change is really just a (generated) javadoc change.