### PR TITLE
Typo "an user" -> "a user"

### DIFF
--- a/common/src/main/java/org/jetbrains/annotations/Nls.java
+++ b/common/src/main/java/org/jetbrains/annotations/Nls.java
@@ -23,7 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Specifies that an element of the program is an user-visible string which needs to be localized.
+ * Specifies that an element of the program is a user-visible string which needs to be localized.
  * This annotation is intended to be used by localization tools for
  * detecting strings which should be reported as requiring localization.
  *


### PR DESCRIPTION
“user” starts with a consonant sound (sound, not letter :) ), so "a" is required