### PR TITLE
Update gradle to 7.6

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -19,4 +19,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip

--- a/module-info/build.gradle
+++ b/module-info/build.gradle
@@ -17,7 +17,7 @@
 sourceCompatibility = 1.9
 
 dependencies {
-    compile project(':java-annotations')
+    implementation project(':java-annotations')
 }
 
 compileJava {


### PR DESCRIPTION
This pull request is a second one in the series of PRs that will add Kotlin Multiplatform support (first one is #101). This PR updates Gradle to 7.6