### PR TITLE
NotNullByDefault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 25.0.0
 ---
 * Added Kotlin Multiplatform artifact (multiplatform-annotations).
 * Removed Java 5 artifact.
+* Added new annotation: `@NotNullByDefault`
 
 Version 24.1.0
 ---

--- a/java-annotations/src/main/java/org/jetbrains/annotations/NotNullByDefault.java
+++ b/java-annotations/src/main/java/org/jetbrains/annotations/NotNullByDefault.java
@@ -1,0 +1,31 @@
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * A meta-annotation applicable to Java class or package, which means that the non-primitive types mentioned
+ * in the following contexts are recursively not-null by default:
+ * <ul>
+ *   <li>Types of fields</li>
+ *   <li>Types of method parameters</li>
+ *   <li>Types of method return values</li>
+ * </ul>
+ * Recursively not-null means that along with types themselves, the components of array types, the type arguments
+ * of generic types and the upper bounds of wildcard types are also not-null.
+ * <p>
+ * The annotation has no effect on overridden method parameters and return values. In this case, the annotations
+ * declared on the original method in the superclass or interface take place.
+ * <p>
+ * The annotation has no effect on newly declared type parameters and their bounds. Only instantiations of
+ * type parameters are constrained.
+ * <p>
+ * The annotation has no effect on local variables.
+ *
+ * @see NotNull
+ * @since 25.0.0
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.TYPE, ElementType.PACKAGE})
+public @interface NotNullByDefault {
+}

--- a/multiplatform-annotations/src/commonMain/kotlin/org/jetbrains/annotations/NotNullByDefault.kt
+++ b/multiplatform-annotations/src/commonMain/kotlin/org/jetbrains/annotations/NotNullByDefault.kt
@@ -1,0 +1,30 @@
+package org.jetbrains.annotations
+
+/**
+ * A meta-annotation applicable to Java class or package, which means that the non-primitive types mentioned
+ * in the following contexts are recursively not-null by default:
+ *
+ *  * Types of fields
+ *  * Types of method parameters
+ *  * Types of method return values
+ *
+ * Recursively not-null means that along with types themselves, the components of array types, the type arguments
+ * of generic types and the upper bounds of wildcard types are also not-null.
+ *
+ *
+ * The annotation has no effect on overridden method parameters and return values. In this case, the annotations
+ * declared on the original method in the superclass or interface take place.
+ *
+ *
+ * The annotation has no effect on newly declared type parameters and their bounds. Only instantiations of
+ * type parameters are constrained.
+ *
+ *
+ * The annotation has no effect on local variables.
+ *
+ * @since 25.0.0
+ */
+@MustBeDocumented
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FILE)
+annotation class NotNullByDefault 


### PR DESCRIPTION
I wanted to add a 'MODULE' target as well, but this would require separate Java 8 and Java 9 versions which will complicate the build, especially taking into account the necessity to support a Kotlin version as well. Let's postpone this.

Not sure about whether it should support newly declared type parameter bounds. Like if we declare `class Foo<T>` under `@NotNullByDefault`, should we assume that it's `class Foo<T extends @NotNull Object>` (that is: cannot be instantiated by a nullable type)? Note that if the class contains a method like `T get();`, it's implicitly assumed that it's `@NotNull T get();`