### PR TITLE
Add signAll task that signs all artifacts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -303,3 +303,7 @@ signing {
     sign(publishing.publications)
     signatories = GpgSignSignatoryProvider()
 }
+
+tasks.register("signAll") {
+    dependsOn(tasks.withType<Sign>())
+}


### PR DESCRIPTION
This will help with adding other targets later since we won't need to update publishing script