### PR TITLE
Fix missing klibs for apple artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ===
 
+Version 26.0.2
+---
+* Fixed missing klibs for apple artifacts.
+
 Version 26.0.1
 ---
 * Fixed sources.jar build (regression after 25.0.0)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ using gradle write the following in the
 `build.gradle` file (Groovy DSL)
 ```
 dependencies {
-    compileOnly 'org.jetbrains:annotations:26.0.1'
+    compileOnly 'org.jetbrains:annotations:26.0.2'
 }
 
 ```
@@ -25,7 +25,7 @@ dependencies {
 or in the `build.gradle.kts` file (Kotlin DSL)
 ```
 dependencies {
-    compileOnly("org.jetbrains:annotations:26.0.1")
+    compileOnly("org.jetbrains:annotations:26.0.2")
 }
 
 ```
@@ -34,7 +34,7 @@ To add a dependency using Maven, write the following in `pom.xml`:
 <dependency>
   <groupId>org.jetbrains</groupId>
   <artifactId>annotations</artifactId>
-  <version>26.0.1</version>
+  <version>26.0.2</version>
   <scope>provided</scope>
 </dependency>
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-projectVersion=26.0.1
+projectVersion=26.0.2
 kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true
 kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
This will hopefully fix #116. I'm not sure because unless we run our CI and generate some artifacts we won't know for sure that this is fixed. I fixed our CI to pin the build to macos machines and on my macos machine the artifacts are produced, so this should work.