### PR TITLE
Update documentation to exclude static methods from `@OverrideOnly`

### DIFF
--- a/src/commonMain/kotlin/org/jetbrains/annotations/ApiStatus.kt
+++ b/src/commonMain/kotlin/org/jetbrains/annotations/ApiStatus.kt
@@ -200,7 +200,7 @@ expect class ApiStatus private constructor() {
      *
      * Indicates that the annotated method is part of SPI (Service Provider Interface), which is intended to be
      * **only implemented or overridden** but not called by clients of the declaring library.
-     * If a class or interface is marked with this annotation it means that all its methods can be only overridden.
+     * If a class or interface is marked with this annotation it means that all its instance methods can be only overridden.
      *
      *
      * Although there is a standard mechanism of `protected` methods, it is not applicable to interface's methods.

--- a/src/jvmMain/java/org/jetbrains/annotations/ApiStatus.java
+++ b/src/jvmMain/java/org/jetbrains/annotations/ApiStatus.java
@@ -149,7 +149,7 @@ public final class ApiStatus {
   /**
    * <p>Indicates that the annotated method is part of SPI (Service Provider Interface), which is intended to be
    * <strong>only implemented or overridden</strong> but not called by clients of the declaring library.
-   * If a class or interface is marked with this annotation it means that all its methods can be only overridden.</p>
+   * If a class or interface is marked with this annotation it means that all its instance methods can be only overridden.</p>
    *
    * <p>Although there is a standard mechanism of {@code protected} methods, it is not applicable to interface's methods.
    * Also, API method may be made {@code public} to allow calls only from different parts of the declaring library but not outside it.</p>

--- a/src/nonJvmMain/kotlin/org/jetbrains/annotations/ApiStatus.kt
+++ b/src/nonJvmMain/kotlin/org/jetbrains/annotations/ApiStatus.kt
@@ -200,7 +200,7 @@ actual class ApiStatus private actual constructor() {
      *
      * Indicates that the annotated method is part of SPI (Service Provider Interface), which is intended to be
      * **only implemented or overridden** but not called by clients of the declaring library.
-     * If a class or interface is marked with this annotation it means that all its methods can be only overridden.
+     * If a class or interface is marked with this annotation it means that all its instance methods can be only overridden.
      *
      *
      * Although there is a standard mechanism of `protected` methods, it is not applicable to interface's methods.


### PR DESCRIPTION
Update Javadoc of `@OverrideOnly` to exclude static methods. While this can technically be considered a semantic change of the annotation, it only removes nonsensical warnings.

![Screenshot showing a warning at a call site of the static method `LeafOccurrenceMapper.withPointer`, reporting that the method can only be overridden.](https://github.com/user-attachments/assets/e28b0e93-0de3-4720-b829-af86931dbe9c)

A warning reporting that a static method (e.g. `LeafOccurrenceMapper.withPointer`) can only be overridden is rather strange, considering that such method is generally impossible to override.

#### Related

* [**"JVM languages | Method can only be overridden" inspection: do not highlight static methods** (IDEA-367007)](https://youtrack.jetbrains.com/issue/IDEA-367007/)
* [**@ApiStatus.OverrideOnly: Do not highlight static methods** (MP-7233)](https://youtrack.jetbrains.com/issue/MP-7233/)
* JetBrains/intellij-community#2938