### PR TITLE
fix(123): @TestOnly should be allowed for ElementType.PACKAGE

### DIFF
--- a/src/commonMain/kotlin/org/jetbrains/annotations/TestOnly.kt
+++ b/src/commonMain/kotlin/org/jetbrains/annotations/TestOnly.kt
@@ -36,7 +36,8 @@ package org.jetbrains.annotations
     AnnotationTarget.PROPERTY_SETTER,
     AnnotationTarget.CONSTRUCTOR,
     AnnotationTarget.FIELD,
-    AnnotationTarget.CLASS
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FILE
 )
 @kotlin.jvm.ImplicitlyActualizedByJvmDeclaration
 expect annotation class TestOnly()

--- a/src/jvmMain/java/org/jetbrains/annotations/TestOnly.java
+++ b/src/jvmMain/java/org/jetbrains/annotations/TestOnly.java
@@ -15,7 +15,11 @@
  */
 package org.jetbrains.annotations;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * A member or type annotated with TestOnly claims that it should be used from testing code only.
@@ -29,6 +33,7 @@ import java.lang.annotation.*;
  * proper API which can be used in production as well as in tests.
  */
 @Documented
-@Retention(RetentionPolicy.CLASS)
-@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.TYPE})
-public @interface TestOnly { }
+@Retention( RetentionPolicy.CLASS )
+@Target( { ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.TYPE, ElementType.PACKAGE } )
+public @interface TestOnly {
+}

--- a/src/nonJvmMain/kotlin/org/jetbrains/annotations/TestOnly.kt
+++ b/src/nonJvmMain/kotlin/org/jetbrains/annotations/TestOnly.kt
@@ -36,6 +36,7 @@ package org.jetbrains.annotations
     AnnotationTarget.PROPERTY_SETTER,
     AnnotationTarget.CONSTRUCTOR,
     AnnotationTarget.FIELD,
-    AnnotationTarget.CLASS
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FILE
 )
 actual annotation class TestOnly


### PR DESCRIPTION
Enable TestOnly annotation on package level.
Solves issue [#123](https://github.com/JetBrains/java-annotations/issues/123]